### PR TITLE
Service Worker Improvements + About Page hiddenElementsStyler Bugfix

### DIFF
--- a/_assets/js/index.js
+++ b/_assets/js/index.js
@@ -4,8 +4,9 @@ $(document).ready(function() {
     const hiddenElementsStyler = new HiddenElementsStyler({
         "#aboutBackground": {
             showTrigger: function ($elem) {
-                if ($(window).width() > 1366) {
-                    $elem.animate({"max-width": $elem.data("width")}, {
+                let windowWidth = $(window).width();
+                if (windowWidth > 1366) {
+                    $elem.animate({"max-width": windowWidth}, {
                         easing: "swing", duration: 1000, complete: function () {
                             $elem.css("max-width", "");
                         }
@@ -14,7 +15,6 @@ $(document).ready(function() {
                     $elem.css("max-width", "");
                 }
             }, hideTrigger: function ($elem) {
-                $elem.data("width", $elem.width());
                 $elem.css("max-width", "1366px");
             }
         },

--- a/service_worker.js
+++ b/service_worker.js
@@ -1,26 +1,40 @@
 self.addEventListener('fetch', function(event) {
-    if (event.request.url.endsWith(".html") || event.request.url.endsWith("/")) {
+    let strippedUrl = stripUrl(event.request.url);
+    if (strippedUrl.endsWith(".html") || strippedUrl.endsWith("/")) {
         event.respondWith(fetch(event.request).then(function(fetchResponse) {
             if (badResponse(fetchResponse)) {
-                caches.match(event.request).then(function(cachedResponse) {
-                    if (cachedResponse) {
-                        return cachedResponse;
-                    }
-                    return fetchResponse;
-                });
+                if (fetchResponse.status === 404) {
+                    strippedUrl = self.location.origin + "/404/";
+                } else {
+                    return caches.match(digestFreeUrl(strippedUrl)).then(function(cachedResponse) {
+                        if (cachedResponse && (stripUrl(cachedResponse.url) === strippedUrl || strippedUrl === self.location.origin + "/404/")) {
+                            return cachedResponse;
+                        }
+                        return fetchResponse;
+                    });
+                }
             }
-            return cacheAndClone(event.request, fetchResponse);
+            return cacheAndClone(digestFreeUrl(strippedUrl), fetchResponse);
+        }).catch(function(error){
+            return caches.match(digestFreeUrl(strippedUrl)).then(function(cachedResponse) {
+                if (cachedResponse && stripUrl(cachedResponse.url) === strippedUrl || strippedUrl === self.location.origin + "/404/") {
+                    return cachedResponse;
+                }
+                throw error;
+            });
         }));
     } else {
-        event.respondWith(caches.match(event.request).then(function(cachedResponse) {
-            if (cachedResponse) {
+        event.respondWith(caches.match(digestFreeUrl(strippedUrl)).then(function(cachedResponse) {
+            if (cachedResponse && stripUrl(cachedResponse.url) === strippedUrl) {
                 return cachedResponse;
             }
             return fetch(event.request).then(function(fetchResponse) {
                 if (badResponse(fetchResponse)) {
                     return fetchResponse;
                 }
-                return cacheAndClone(event.request, fetchResponse);
+                return cacheAndClone(digestFreeUrl(strippedUrl), fetchResponse);
+            }).catch(function(error){
+                throw error;
             });
         }));
     }
@@ -37,4 +51,25 @@ var cacheAndClone = function(key, response) {
             cache.put(key, responseToCache);
         });
     return response;
+};
+
+var stripUrl = function(url) {
+    // Remove query params / id targets
+    let strippedUrl = url.split("?")[0].split("#")[0];
+    // Compress running slashes
+    strippedUrl.replace(/\/*/, "/");
+    // Remove trailing slash
+    if (strippedUrl[strippedUrl.length-1] === "/") {
+        strippedUrl = strippedUrl.substring(0, strippedUrl.length-1);
+    }
+    // Fix directory requests back with the trailing /
+    if (strippedUrl.substring(self.location.origin.length).indexOf(".") === -1) {
+        strippedUrl = strippedUrl + "/";
+    }
+    return strippedUrl;
+};
+
+var digestFreeUrl = function(url) {
+    // Eliminate asset digest token
+    return url.replace(/(-[^.]*\.)(?!.*-[^.]*\.)/, ".");
 };


### PR DESCRIPTION
# Why
The caching mechanism was sweet, but lots of unnecessary files would build up over time.
There was a visual bug on the about page!
# What
Make caching no longer care about fluff parameters and uri mistakes.
Make 404 actually cache off 404 errors.
Actually catch fetch errors.
Use digest-less and param-stripped urls as the keys for caching, so that cache-busting asset updates REPLACE the outdated ones!
Fix bug where the hiddenElementStyler was shrinking the background instead of growing it when the screen size increased from the original window size.